### PR TITLE
Remove the steps to release a new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,3 @@ metro
 
 This will register the current build of `dist/index.js` as a global command `metro`. This is useful
 for testing the CLI tool without having to publish to npm.
-
-## Releasing a new version
-
-1. Write code.
-1. Bump version in package.json, ex: `v0.0.5`.
-1. Add changes to CHANGELOG.md.
-1. Open PR, review, merge to main.
-1. Draft a [new release](https://github.com/0xmetropolis/cli/releases/new).
-
-    - Choose tag: `v0.0.5`.
-    - Release title: `v0.0.5`.
-    - Description: Copy/paste new additions in CHANGELOG.md
-    - Publish release.
-
-1. Confirm [new release](https://www.npmjs.com/package/@0xmetropolis/cli).


### PR DESCRIPTION
# Problem

The README is public facing, so we do not need to include steps to release a new version.

# Solution

Move the steps to [notion](https://www.notion.so/sonarlabs/Testing-and-releasing-metro-CLI-175eb3086bfd483e8fd364ec0a090771?pvs=4)

### Checklist

- [x] Documentation updated

[ticket](https://linear.app/metropolis/issue/MP-256/update-cli-readme)
