### PR TITLE
Remove CLI Deprecation from Metal

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Metal.
 
 ```bash
 # with npm
-npm install -g @0xmetropolis/cli
+npm install -g @0xmetropolis/metal
 
 # with yarn
-yarn global add @0xmetropolis/cli
+yarn global add @0xmetropolis/metal
 ```
 
 # Usage
@@ -31,7 +31,7 @@ In the directory of your Foundry project, run the following command:
 metro preview --chain-id 1 $PATH_TO_DEPLOY_SCRIPT
 ```
 
-NOTE: Metropolis wraps around `forge` commands, but `metro preview` does _not_ send any deployment
+NOTE: Metal wraps around `forge` commands, but `metro preview` does _not_ send any deployment
 transactions.
 
 This will compile your contracts and start a deployment simulation. Once the simulation is done,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "0xmetropolis/metal",
+  "name": "@0xmetropolis/metal",
   "version": "0.4.0",
   "description": "Smart contract visualization tool.",
   "author": "Metropolis (@0xmetropolis)",


### PR DESCRIPTION
## Background

We have deprecated the metropolis/cli package. Re-point the package.json to metal and remove the deprecation related notes.

## Checklist

- [x] Documentation updated
