### PR TITLE
Capture pull and include version in analytics

### DIFF
--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -5,6 +5,7 @@ import { getMetalCodegenFromArtifactBundle, logMetalDirStructure } from '../util
 import { getDeploymentArtifacts } from '../utils/preview-service';
 import { decompressArtifactZip, tryLoadPreviousAddresses } from '../utils/pull';
 import { writeCodegenToDisk } from '../utils/pull';
+import { sendCliCommandAnalytics } from '../utils/analytics';
 
 export const command = 'pull';
 export const description = `Pull artifacts from `;
@@ -58,4 +59,5 @@ export const handler = async (yargs: HandlerInput) => {
 
   logInfo('Wrote deployment artifacts to the `metal/` directory 🎉\n');
   logMetalDirStructure();
+  sendCliCommandAnalytics('pull');
 };

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,9 +1,10 @@
 import { logDebug } from '.';
+import { version } from '../../package.json';
 import { PREVIEW_SERVICE_URL } from '../constants';
 import { checkAuthentication } from './auth';
 
 export const sendCliCommandAnalytics = async (
-  cliCommand: 'import' | 'deploy' | 'preview' | 'auth',
+  cliCommand: 'import' | 'deploy' | 'preview' | 'auth' | 'pull',
 ) => {
   const auth = await checkAuthentication();
   const authHeaders =
@@ -17,7 +18,7 @@ export const sendCliCommandAnalytics = async (
         'Content-Type': 'application/json',
         ...authHeaders,
       },
-      body: JSON.stringify({ cliCommand }),
+      body: JSON.stringify({ cliCommand, version }),
     });
 
     logDebug(request.status);

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,7 +1,8 @@
 import { logDebug } from '.';
-import { version } from '../../package.json';
 import { PREVIEW_SERVICE_URL } from '../constants';
 import { checkAuthentication } from './auth';
+
+const { version } = require('../../package.json');
 
 export const sendCliCommandAnalytics = async (
   cliCommand: 'import' | 'deploy' | 'preview' | 'auth' | 'pull',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,9 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "sourceMap": true,
     "outDir": "dist"
   },
-  "include": [
-    "src/**/*"
-  ]
+  "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,10 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "resolveJsonModule": true,
     "sourceMap": true,
     "outDir": "dist"
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }


### PR DESCRIPTION
## Background

1. We are not currently capturing `pull` commands 
2. We don't have any way of knowing which versions are in use. 

## Checklist

- [x] Documentation updated
- [x] Tested code changes

[ticket](https://linear.app/metropolis/issue/MP-518/[analytics]-fix-edge-cases)
