### PR TITLE
feat: catch wrap post-deployment association

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -14,6 +14,8 @@ import {
   openInBrowser,
   printPreviewLinkWithASCIIArt,
 } from '../utils';
+import { sendCliCommandAnalytics } from '../utils/analytics';
+import { authenticateAndAssociateDeployment_safe, checkAuthentication } from '../utils/auth';
 import {
   getContractMetadata,
   getScriptDependencies,
@@ -23,13 +25,10 @@ import {
   runForgeScript,
 } from '../utils/foundry';
 import { getRepoMetadata } from '../utils/git';
+import { checkRepoForUncommittedChanges } from '../utils/import';
 import { ChainConfig, fetchChainConfig, uploadDeploymentData } from '../utils/preview-service';
 import { getCLIVersion } from '../utils/version';
 import inquirer = require('inquirer');
-import { checkAuthentication } from '../utils/auth';
-import { checkRepoForUncommittedChanges } from '../utils/import';
-import { authenticateAndAssociateDeployment } from '../utils/auth';
-import { sendCliCommandAnalytics } from '../utils/analytics';
 
 export const command = 'deploy';
 export const description = `Run your deployments against a live network and generate a Metal preview`;
@@ -172,7 +171,7 @@ export const handler = async (yargs: HandlerInput) => {
   const metalWebUrl = `${PREVIEW_WEB_URL}/preview/${deploymentId}`;
   // if the user is not authenticated, ask them if they wish to add the deployment to their account
   if (authenticationStatus.status !== 'authenticated' && !doNotCommunicateWithPreviewService)
-    await authenticateAndAssociateDeployment(deploymentId, 'deployment');
+    await authenticateAndAssociateDeployment_safe(deploymentId, 'deployment');
 
   printPreviewLinkWithASCIIArt(metalWebUrl);
 

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -3,6 +3,8 @@ import { PREVIEW_WEB_URL, doNotCommunicateWithPreviewService } from '../constant
 import { DeploymentRequestParams, ScriptMetadata } from '../types';
 import {
   getFlagValueFromArgv,
+  logDebug,
+  logError,
   logInfo,
   openInBrowser,
   printPreviewLinkWithASCIIArt,

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -3,8 +3,6 @@ import { PREVIEW_WEB_URL, doNotCommunicateWithPreviewService } from '../constant
 import { DeploymentRequestParams, ScriptMetadata } from '../types';
 import {
   getFlagValueFromArgv,
-  logDebug,
-  logError,
   logInfo,
   openInBrowser,
   printPreviewLinkWithASCIIArt,

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -22,7 +22,8 @@ import {
   printPreviewLinkWithASCIIArt,
   replaceFlagValues,
 } from '../utils';
-import { authenticateAndAssociateDeployment, checkAuthentication } from '../utils/auth';
+import { sendCliCommandAnalytics } from '../utils/analytics';
+import { authenticateAndAssociateDeployment_safe, checkAuthentication } from '../utils/auth';
 import {
   getContractMetadata,
   getScriptDependencies,
@@ -34,7 +35,6 @@ import {
 import { getRepoMetadata } from '../utils/git';
 import { createMetalFork } from '../utils/preview-service';
 import { getCLIVersion } from '../utils/version';
-import { sendCliCommandAnalytics } from '../utils/analytics';
 
 export const command = 'preview';
 export const description = `Generate preview of transactions from your Forge script`;
@@ -221,7 +221,7 @@ export const handler = async (yargs: HandlerInput) => {
   logInfo(`Preview simulation successful! 🎉\n\n`);
   // if the user is not authenticated, ask them if they wish to add the deployment to their account
   if (authenticationStatus.status !== 'authenticated' && !doNotCommunicateWithPreviewService)
-    await authenticateAndAssociateDeployment(previewId, 'preview');
+    await authenticateAndAssociateDeployment_safe(previewId, 'preview');
 
   printPreviewLinkWithASCIIArt(previewServiceUrl);
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -436,3 +436,13 @@ export const authenticateAndAssociateDeployment = async (
   // associate the deployment with the user
   await addDeploymentToAccount(deploymentId, authStatus.access_token);
 };
+
+export const authenticateAndAssociateDeployment_safe = async (
+  deploymentId: UUID,
+  promptLabel: 'preview' | 'deployment',
+) =>
+  await authenticateAndAssociateDeployment(deploymentId, promptLabel).catch(e => {
+    logDebug(e);
+
+    logError('Authentication Error!\nPlease run `metal auth` and try again.');
+  });


### PR DESCRIPTION
## Background

<!-- Give context for PR (if necessary) -->

## Checklist

- [x] Documentation updated
- [x] Tested code changes

[ticket](https://linear.app/metropolis/issue/MP-522/bug-catch-auth-errors-when-post-associating-deployments)
