### PR TITLE
fix: use script path as forge build entrypoint

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -81,11 +81,12 @@ export const handler = async (yargs: HandlerInput) => {
     broadcastArtifacts,
   );
 
-  // run forge build now that we're on the correct commit sha
-  await buildProject();
-
   // search for the script file in the current directory (if necessary, prompt the user to select one)
   const pathToScript = await findScriptPath(foundryConfig, selectedScript);
+
+  // run forge build now that we're on the correct commit sha
+  await buildProject(pathToScript);
+
   // get an array of all the solidity files that need to be uploaded
   const solidityFilePaths = [pathToScript, ...getScriptDependencies(foundryConfig, pathToScript)];
   const repoMetadata = getRepoMetadata(solidityFilePaths);

--- a/src/utils/import.ts
+++ b/src/utils/import.ts
@@ -167,11 +167,15 @@ export const promptForBroadcastArtifact = async (foundryConfig: FoundryConfig) =
   };
 };
 
-export const buildProject = async () => {
+export const buildProject = async (pathToScript: string) => {
   const buildOptionsIdx = process.argv.findIndex(arg => arg === '--build-options');
   const userSpecifiedBuildOpts = buildOptionsIdx !== -1;
   // interpret anything after `--build-options` as options to pass to `forge build`
   const buildOptions = userSpecifiedBuildOpts ? process.argv.slice(buildOptionsIdx + 1) : [];
+
+  // @dev we want the script file to be the entrypoint for the build command,
+  //   in the case where the script lives outside the contracts directory
+  const buildOptionsIncludingScript = [...buildOptions, '--contracts', pathToScript];
 
   if (userSpecifiedBuildOpts)
     logInfo(
@@ -180,7 +184,7 @@ export const buildProject = async () => {
       )})...`,
     );
 
-  await runForgeBuild(buildOptions).catch(() => {
+  await runForgeBuild(buildOptionsIncludingScript).catch(() => {
     logError(`Forge build failed. Aborting import.`);
 
     exit(


### PR DESCRIPTION
## Background

<!-- Give context for PR (if necessary) -->

## Checklist

- [x] Documentation updated
- [x] Tested code changes

[ticket](https://linear.app/metropolis/issue/MP-524/ensure-forge-build-includes-script-file)
