### PR TITLE
import: skip confusing message if no options found

### DIFF
--- a/src/utils/foundry.ts
+++ b/src/utils/foundry.ts
@@ -222,7 +222,7 @@ export const runForgeScript = async (scriptArgs: string[]) => {
 };
 
 const mutateForgeMessages = (msg: string | number | bigint | boolean | object): string => {
-  let msgAsString = msg.toString();
+  const msgAsString = msg.toString();
   // search the output for messages that should be filtered
 
   if (msgAsString.includes('Sending transactions')) return '';

--- a/src/utils/import.ts
+++ b/src/utils/import.ts
@@ -95,7 +95,7 @@ const selectBroadcastArtifact = async (
       .map<Promise<inquirer.ChoiceOptions>>(async fileName => {
         // if the file is the run-latest.json, then open the file to see when the run timestamp was
         if (fileName === 'run-latest.json') {
-          let runLatest = await loadBroadcastArtifacts(`${pathToArtifacts}/${fileName}`);
+          const runLatest = await loadBroadcastArtifacts(`${pathToArtifacts}/${fileName}`);
 
           return {
             name: `${fileName} (${new Date(runLatest.timestamp * 1000).toLocaleString()})`,
@@ -112,19 +112,23 @@ const selectBroadcastArtifact = async (
       }),
   );
 
-  if (options.length === 0) await exit(`No valid broadcast files found in ${pathToArtifacts}`);
-
-  return (
-    await inquirer.prompt([
-      {
-        type: 'list',
-        name: 'broadcast',
-        message: 'Select a broadcast artifact',
-        // reverse the list so the most recent broadcasts are at the top
-        choices: options.reverse(),
-      },
-    ])
-  ).broadcast;
+  if (options.length === 0) {
+    const error = `No valid broadcast files found in ${pathToArtifacts}`;
+    await exit(error);
+    return error;
+  } else {
+    return (
+      await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'broadcast',
+          message: 'Select a broadcast artifact',
+          // reverse the list so the most recent broadcasts are at the top
+          choices: options.reverse(),
+        },
+      ])
+    ).broadcast;
+  }
 };
 
 // gets the broadcast artifact the user wants to upload


### PR DESCRIPTION
## Problem

If `metal import` finds no broadcast artifact options, it asks the user to select an artifact from 0 options and then exits.
<img width="563" alt="image" src="https://github.com/0xmetropolis/metal/assets/1020682/948b493c-125d-4cce-9020-7775eb55de15">


## Solution

Exit without prompting the user.
<img width="483" alt="image" src="https://github.com/0xmetropolis/metal/assets/1020682/872fd134-d1c0-425b-8ec1-60ee709d906e">
## Checklist

- [ ] Documentation updated
- [ ] Tested code changes

[ticket](https://linear.app/metropolis/issue/MP-568/[bug]-metal-import-crashes)
